### PR TITLE
Non recursive ADTs flattening

### DIFF
--- a/src/absadt.rs
+++ b/src/absadt.rs
@@ -90,8 +90,7 @@ fn initialize_dtyp(typ: Typ, encs: &mut BTreeMap<Typ, Encoder>) -> Res<()> {
         typ: typ.clone(),
         n_params,
         approxs,
-        statically_simplified: false,
-        dinamically_simplified: false,
+        simplification: enc::SimplificationKind::None
     };
     let r = encs.insert(typ, enc);
     debug_assert!(r.is_none());

--- a/src/absadt.rs
+++ b/src/absadt.rs
@@ -37,6 +37,7 @@
 //! ## Some Assumptions
 //! - set of ADT does not change from start to end during `work`
 //!   - they are defined as the global hashconsed objects
+use adt_graph::{ADTDependencyGraph, Category};
 use chc::AbsInstance;
 use enc::Encoder;
 
@@ -45,6 +46,7 @@ use crate::info::{Pred, VarInfo};
 
 use crate::unsat_core::UnsatRes;
 
+mod adt_graph;
 mod catamorphism_parser;
 mod chc;
 mod chc_solver;
@@ -65,6 +67,7 @@ pub struct AbsConf<'original> {
     pub encs: BTreeMap<Typ, Encoder>,
     epoch: usize,
     profiler: &'original Profiler,
+    dependency_graph: adt_graph::ADTDependencyGraph,
 }
 
 fn initialize_dtyp(typ: Typ, encs: &mut BTreeMap<Typ, Encoder>) -> Res<()> {
@@ -87,6 +90,8 @@ fn initialize_dtyp(typ: Typ, encs: &mut BTreeMap<Typ, Encoder>) -> Res<()> {
         typ: typ.clone(),
         n_params,
         approxs,
+        statically_simplified: false,
+        dinamically_simplified: false,
     };
     let r = encs.insert(typ, enc);
     debug_assert!(r.is_none());
@@ -121,7 +126,7 @@ impl<'original> AbsConf<'original> {
         let cexs = Vec::new();
         let solver = conf.solver.spawn("absadt", Parser, original)?;
         let encs = BTreeMap::new();
-
+        let dependency_graph = adt_graph::ADTDependencyGraph::default();
         Ok(AbsConf {
             instance,
             cexs,
@@ -129,7 +134,18 @@ impl<'original> AbsConf<'original> {
             encs,
             epoch: 0,
             profiler,
+            dependency_graph,
         })
+    }
+
+    fn flatten_non_recursive_adt(&mut self) -> Res<()> {
+        self.dependency_graph.flatten_adt(&mut self.encs, Category::Static)?;
+        self.dependency_graph.flatten_adt(&mut self.encs, Category::Dynamic)?;
+        log_debug!("After the flattening");
+        for (typ, enc) in self.encs.iter() {
+            log_debug!("{} {}", typ, enc);
+        }
+        Ok(())
     }
 
     fn initialize_encs(&mut self) -> Res<()> {
@@ -147,6 +163,7 @@ impl<'original> AbsConf<'original> {
             }
             initialize_encs_for_term(&c.lhs_term, &mut self.encs)?;
         }
+        self.dependency_graph = ADTDependencyGraph::new(&self.encs)?;
         Ok(())
     }
 
@@ -264,8 +281,8 @@ impl<'original> AbsConf<'original> {
 
         // The approximation map
         if let Some(catamorphism_str) = approximation_file {
-            let parsed_approximations =  catamorphism_parser::parse_catamorphism(catamorphism_str)?;
-			log_info!("Testing the input approximations");
+            let parsed_approximations = catamorphism_parser::parse_catamorphism(catamorphism_str)?;
+            log_info!("Testing the input approximations");
             self.encs =
                 catamorphism_parser::build_encoding_from_approx(parsed_approximations, &self.encs)?;
             let encoded = self.encode();
@@ -282,6 +299,8 @@ impl<'original> AbsConf<'original> {
                 }
             }
         }
+
+        self.flatten_non_recursive_adt()?;
 
         let r = loop {
             self.epoch += 1;
@@ -308,10 +327,7 @@ impl<'original> AbsConf<'original> {
 }
 
 impl<'a> AbsConf<'a> {
-    pub fn encode_clause(
-        &self,
-        c: &chc::AbsClause
-    ) -> chc::AbsClause {
+    pub fn encode_clause(&self, c: &chc::AbsClause) -> chc::AbsClause {
         let ctx = enc::EncodeCtx::new(&self.encs);
         let (new_vars, introduced) = enc::tr_varinfos(&self.encs, &c.vars);
         let encode_var = |_, var| {
@@ -402,8 +418,7 @@ impl<'a> AbsConf<'a> {
         let head_argument = term::dtyp_new(
             typ.clone(),
             constr_name,
-            vars
-                .iter()
+            vars.iter()
                 .map(|v| term::var(v.idx, v.typ.clone()))
                 .collect(),
         );
@@ -418,7 +433,7 @@ impl<'a> AbsConf<'a> {
                         args: args.into(),
                     };
                     lhs_preds.push(app);
-                },
+                }
                 None => {
                     assert!(!var.typ.is_dtyp());
                 }
@@ -459,10 +474,7 @@ impl<'a> AbsConf<'a> {
         for (typ, _) in self.encs.iter() {
             let pi = preds.next_index();
             let p = Pred::new(
-                format!(
-                    "encoder_pred_{}",
-                    enc::to_valid_symbol(typ.to_string()),
-                ),
+                format!("encoder_pred_{}", enc::to_valid_symbol(typ.to_string()),),
                 pi,
                 vec![typ.clone()].into(),
             );
@@ -504,7 +516,7 @@ impl<'a> AbsConf<'a> {
                 let app = chc::PredApp {
                     pred: *approx_pred,
                     args: args.into(),
-                    };
+                };
                 lhs_preds.push(app);
             }
             res.push(chc::AbsClause {
@@ -525,14 +537,9 @@ impl<'a> AbsConf<'a> {
         clauses.extend(clauses2);
 
         // 2. encode the clauses by using the current catamorphism
-        let preds = preds
-            .iter()
-            .map(|p| self.encode_pred(p))
-            .collect();
+        let preds = preds.iter().map(|p| self.encode_pred(p)).collect();
 
-        let clauses: Vec<_> = clauses.iter()
-            .map(|c| self.encode_clause(c))
-            .collect();
+        let clauses: Vec<_> = clauses.iter().map(|c| self.encode_clause(c)).collect();
 
         self.instance.clone_with_clauses(clauses, preds)
     }

--- a/src/absadt/adt_graph.rs
+++ b/src/absadt/adt_graph.rs
@@ -1,0 +1,231 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::conf;
+use crate::term;
+use crate::typ;
+use crate::VarMap;
+use crate::absadt::enc::{Enc, Approx, Encoder};
+use crate::errors::Res;
+use crate::info::VarInfo;
+use crate::term::typ::{RTyp, Typ};
+
+pub enum Category {
+    Static, Dynamic
+}
+
+#[derive(Default)]
+pub struct ADTDependencyGraph {
+    dependencies: BTreeMap<Typ, BTreeSet<Typ>>,
+    // An ADT is said statically simplifiable when it is not recursive and the
+    // only dependencies are:
+    // - None or
+    // - A SMT primitive type (Int) or
+    // - Another statically simplifiable ADT
+    statically_simplifiable: BTreeSet<Typ>,
+    // An ADT is said dynamically simplifiable when there is no loop (any loop size)
+    // into itself and it is not statically simplifiable
+    dynamically_simplifiable: BTreeSet<Typ>,
+    initial_approx_degrees: BTreeMap<RTyp, usize>,
+}
+
+impl ADTDependencyGraph {
+    pub fn new(adts: &BTreeMap<Typ, Encoder>) -> Res<Self> {
+        let all_adts: BTreeSet<Typ> = adts.keys().map(|item| item.clone()).collect();
+        let mut dependencies = BTreeMap::new();
+
+        for adt_rtyp in all_adts.iter() {
+            if adt_rtyp.dtyp_inspect().is_some() {
+                dependencies.insert(adt_rtyp.clone(), adt_rtyp.dtyp_dependencies(&all_adts)?);
+            }
+        }
+
+        let statically_simplifiable = Self::init_statically_simplifiable(&dependencies);
+        let dynamically_simplifiable =
+            Self::init_dynamically_simplifiable(&dependencies, &statically_simplifiable);
+        let initial_approx_degrees = Self::init_approx_degrees(&all_adts);
+
+        Ok(Self {
+            dependencies,
+            statically_simplifiable,
+            dynamically_simplifiable,
+            initial_approx_degrees,
+        })
+    }
+
+    fn init_statically_simplifiable(dependencies: &BTreeMap<Typ, BTreeSet<Typ>>) -> BTreeSet<Typ> {
+        let mut return_vec = BTreeSet::new();
+        let mut changed = true;
+
+        while changed {
+            changed = false;
+            for (typ, deps) in dependencies.iter() {
+                if !return_vec.contains(typ) {
+                    if deps
+                        .iter()
+                        .all(|dep| matches!(dep.get(), RTyp::Int) || return_vec.contains(dep))
+                    {
+                        return_vec.insert(typ.clone());
+                        changed = true;
+                    }
+                }
+            }
+        }
+        return_vec
+    }
+
+    fn init_dynamically_simplifiable(
+        dependencies: &BTreeMap<Typ, BTreeSet<Typ>>,
+        statically_simplifiable: &BTreeSet<Typ>,
+    ) -> BTreeSet<Typ> {
+        let is_self_recursive = |start: &Typ| -> bool {
+            let mut visited = BTreeSet::new();
+            let mut stack = vec![start];
+            while let Some(typ) = stack.pop() {
+                for dep_set in dependencies.get(typ).iter() {
+                    for dep in dep_set.iter() {
+                        if visited.insert(dep) {
+                            stack.push(dep);
+                        }
+                        if dep == start {
+                            return true;
+                        }
+                    }
+                }
+            }
+            false
+        };
+
+        dependencies
+            .keys()
+            .filter(|t| !(is_self_recursive(t) || statically_simplifiable.contains(t)))
+            .map(|t| t.clone())
+            .collect()
+    }
+
+    fn init_approx_degrees(all_adt: &BTreeSet<Typ>) -> BTreeMap<RTyp, usize> {
+        let mut degree_map = BTreeMap::new();
+        for typ in all_adt.iter() {
+            typ.get().compute_approximation_degree(all_adt, &mut degree_map);
+        }
+        degree_map
+    }
+
+    fn get_simplifiable(&self, category_to_flatten: &Category) -> BTreeMap<Typ, usize> {
+        let list = match category_to_flatten {
+            Category::Dynamic => &self.dynamically_simplifiable,
+            Category::Static => &self.statically_simplifiable,
+        };
+        list
+            .iter()
+            .map(|typ| {
+                (
+                    typ.clone(),
+                    *self.initial_approx_degrees.get(typ).unwrap(),
+                )
+            })
+            .collect()
+    }
+
+    fn get_dependant_on(&self, category_to_flatten: &Category) -> BTreeSet<Typ> {
+        let criterion = match category_to_flatten {
+            Category::Dynamic => &self.dynamically_simplifiable,
+            Category::Static => &self.statically_simplifiable,
+        };
+        self.dependencies
+            .iter()
+            .filter(|(_, deps)| {
+                deps.iter()
+                    .any(|typ| criterion.contains(typ))
+            })
+            .map(|(key, _)| key.clone())
+            .collect()
+    }
+
+    pub fn flatten_adt(&self, encs: &mut BTreeMap<Typ, Enc<Approx>>, category_to_flatten: Category) -> Res<()> {
+        let simplifiable: BTreeMap<Typ, usize> = self.get_simplifiable(&category_to_flatten);
+        let typs: BTreeSet<Typ> = self.get_dependant_on(&category_to_flatten);
+        // Expand the signature of types dependant on simplifiable ADTs
+        for dep_typ in typs {
+            let (rdtyp, parameter) = dep_typ.dtyp_inspect().unwrap();
+            let enc = &mut encs.get_mut(&dep_typ).unwrap();
+            for (constructor_name, constructor_args) in rdtyp.news.iter() {
+                let mut new_signature = VarMap::<VarInfo>::new();
+                for (arg_name, arg_typ) in constructor_args.iter() {
+                    if let Ok(argument_concrete_typ) = arg_typ.to_type(Some(parameter)) {
+                        for idx in 0..*self.initial_approx_degrees.get(&argument_concrete_typ).unwrap_or(&1) {
+                            new_signature.push(VarInfo {
+                                name: format!("{arg_name}_{idx}",),
+                                typ: typ::int(),
+                                idx: new_signature.next_index(),
+                                active: true,
+                            });
+                        }
+                    }
+                    else{
+                        new_signature.push(VarInfo {
+                            name: format!("{arg_name}",),
+                            typ: typ::int(),
+                            idx: new_signature.next_index(),
+                            active: true,
+                        });
+                    }
+                }
+                enc.approxs.get_mut(constructor_name).unwrap().args = new_signature;
+            }
+        }
+
+        // Expanding the approximation body
+        for (typ, approx_deg) in simplifiable.iter() {
+            let enc = encs.get_mut(&typ).unwrap();
+            enc.n_params = *approx_deg;
+            if matches!(category_to_flatten, Category::Dynamic) {
+                enc.dinamically_simplified = true;
+            }
+            else {
+                enc.statically_simplified = true;
+            }
+            let n_constr = enc.approxs.keys().len();
+            let approximations = &mut enc.approxs;
+            for (idx, (_, approx)) in approximations.iter_mut().enumerate() {
+                approx.expand_signature(&simplifiable);
+                approx.terms = vec![];
+                if n_constr > 1 {
+                    //Discriminate the constructor
+                    approx.terms.push(term::int(idx));
+                }
+
+                for arg in approx.args.iter() {
+                    approx.terms.push(term::int_var(arg.idx));
+                }
+                // Final padding
+                if approx.terms.len() < enc.n_params {
+                    for _ in approx.terms.len()..enc.n_params {
+                        approx.terms.push(term::int_zero());
+                    }
+                }
+                debug_assert_eq!(approx.terms.len(), *approx_deg);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for ADTDependencyGraph {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "digraph G {{\n",)?;
+        for (node, neighbors) in self.dependencies.iter() {
+            let color = if self.statically_simplifiable.contains(&node) {
+                " [color=red]"
+            } else if self.dynamically_simplifiable.contains(&node) {
+                " [color=blue]"
+            } else {
+                ""
+            };
+            write!(f, "    \"{}\" {};\n", node, color)?;
+            for neighbor in neighbors {
+                write!(f, "    \"{}\" -> \"{}\";\n", node, neighbor)?;
+            }
+        }
+        write!(f, "}}",)
+    }
+}

--- a/src/absadt/adt_graph.rs
+++ b/src/absadt/adt_graph.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::conf;
+use crate::absadt::enc::SimplificationKind;
 use crate::term;
 use crate::typ;
 use crate::VarMap;
@@ -13,17 +14,64 @@ pub enum Category {
     Static, Dynamic
 }
 
+/// Struct to manage all the type dependencies.
+///
+/// It introduces the concept of *statically simplifiable* and *dynamically
+/// simplifiable* for a given type.
+/// # Definitions
+/// ## Statically simplifiable
+/// An ADT is said statically simplifiable when it is not recursive and the
+/// only dependencies are:
+/// - None or
+/// - A SMT primitive type (Int) or
+/// - Another statically simplifiable ADT
+///
+/// Its approximation is fixed before the CEGAR loop and remains the same
+/// throughout the whole execution.
+/// ## Dynamically simplifiable
+/// An ADT is said dynamically simplifiable:
+/// - There is no loop (even with size > 1) into itself and
+/// - It is not statically simplifiable
+///
+/// If an ADT is *dynamically simplifiable* then its approximation degree and
+/// its arguments are adjusted during the CEGAR loop according to the dependency
+/// approximation degree.
+/// # Examples
+/// ## Statically simplifiable
+/// ```text
+/// (declare-datatypes
+///  ( (Color 0) )
+///  ( ( (Red (red Int)) (Green (green Int)) (Blue) (Yellow) ) ))
+/// ```
+/// Is statically simplified to:
+/// ```text
+/// Red(red: Int)     -> (1, red)
+/// Green(green: Int) -> (2, green)
+/// Blue              -> (3, 0)
+/// Yellow            -> (4, 0)
+/// ```
+/// ## Dynamically simplifiable
+/// ```text
+/// (declare-datatypes
+///  ( (List 0) )
+///  ( ( Nil (Cons (head Int) (tail List)) ) ))
+/// (declare-datatypes
+///  ( (Tuple 0) )
+///  ( ( (TupColor (first List) (second Color)) ) ))
+/// ```
+/// Is dynamically simplified to:
+/// ```text
+/// TupColor (first, second_1, second_2) -> (first, second_1, second_2)
+/// ```
+/// If the approximation degree for `List` was 2 then, the simplification for
+/// `Tuple` would have been:
+/// ```text
+/// TupColor (first_1, first_2, second_1, second_2) -> (first_1, first_2, second_1, second_2)
+/// ```
 #[derive(Default)]
 pub struct ADTDependencyGraph {
     dependencies: BTreeMap<Typ, BTreeSet<Typ>>,
-    // An ADT is said statically simplifiable when it is not recursive and the
-    // only dependencies are:
-    // - None or
-    // - A SMT primitive type (Int) or
-    // - Another statically simplifiable ADT
     statically_simplifiable: BTreeSet<Typ>,
-    // An ADT is said dynamically simplifiable when there is no loop (any loop size)
-    // into itself and it is not statically simplifiable
     dynamically_simplifiable: BTreeSet<Typ>,
     initial_approx_degrees: BTreeMap<RTyp, usize>,
 }
@@ -35,14 +83,14 @@ impl ADTDependencyGraph {
 
         for adt_rtyp in all_adts.iter() {
             if adt_rtyp.dtyp_inspect().is_some() {
-                dependencies.insert(adt_rtyp.clone(), adt_rtyp.dtyp_dependencies(&all_adts)?);
+                dependencies.insert(adt_rtyp.clone(), adt_rtyp.dtyp_typs_in_news()?);
             }
         }
 
         let statically_simplifiable = Self::init_statically_simplifiable(&dependencies);
         let dynamically_simplifiable =
             Self::init_dynamically_simplifiable(&dependencies, &statically_simplifiable);
-        let initial_approx_degrees = Self::init_approx_degrees(&all_adts);
+        let initial_approx_degrees = Self::init_approx_degrees(&all_adts)?;
 
         Ok(Self {
             dependencies,
@@ -102,12 +150,12 @@ impl ADTDependencyGraph {
             .collect()
     }
 
-    fn init_approx_degrees(all_adt: &BTreeSet<Typ>) -> BTreeMap<RTyp, usize> {
+    fn init_approx_degrees(all_adt: &BTreeSet<Typ>) -> Res<BTreeMap<RTyp, usize>> {
         let mut degree_map = BTreeMap::new();
         for typ in all_adt.iter() {
-            typ.get().compute_approximation_degree(all_adt, &mut degree_map);
+            typ.get().compute_approximation_degree(&mut degree_map, 1)?;
         }
-        degree_map
+        Ok(degree_map)
     }
 
     fn get_simplifiable(&self, category_to_flatten: &Category) -> BTreeMap<Typ, usize> {
@@ -153,12 +201,13 @@ impl ADTDependencyGraph {
                 for (arg_name, arg_typ) in constructor_args.iter() {
                     if let Ok(argument_concrete_typ) = arg_typ.to_type(Some(parameter)) {
                         for idx in 0..*self.initial_approx_degrees.get(&argument_concrete_typ).unwrap_or(&1) {
-                            new_signature.push(VarInfo {
-                                name: format!("{arg_name}_{idx}",),
-                                typ: typ::int(),
-                                idx: new_signature.next_index(),
-                                active: true,
-                            });
+                            new_signature.push(
+                                VarInfo::new(
+                                    format!("{arg_name}_{idx}"),
+                                    typ::int(),
+                                    new_signature.next_index()
+                                )
+                            );
                         }
                     }
                     else{
@@ -178,12 +227,10 @@ impl ADTDependencyGraph {
         for (typ, approx_deg) in simplifiable.iter() {
             let enc = encs.get_mut(&typ).unwrap();
             enc.n_params = *approx_deg;
-            if matches!(category_to_flatten, Category::Dynamic) {
-                enc.dinamically_simplified = true;
-            }
-            else {
-                enc.statically_simplified = true;
-            }
+            enc.simplification = match category_to_flatten {
+                Category::Dynamic => SimplificationKind::DynamicApprox,
+                Category::Static => SimplificationKind::StaticApprox,
+            };
             let n_constr = enc.approxs.keys().len();
             let approximations = &mut enc.approxs;
             for (idx, (_, approx)) in approximations.iter_mut().enumerate() {
@@ -228,4 +275,60 @@ impl std::fmt::Display for ADTDependencyGraph {
         }
         write!(f, "}}",)
     }
+}
+
+#[test]
+fn test_static_adt_detection() {
+    use crate::dtyp::DTyp;
+    use crate::dtyp::PartialTyp;
+    use crate::dtyp::TPrmIdx;
+    use crate::dtyp::RDTyp;
+    use crate::parse::Pos;
+
+    let dummy_pos = Pos::default();
+    let param_0: TPrmIdx = 0.into();
+    let ptyp = PartialTyp::DTyp (
+        "List".into(), dummy_pos, vec![ PartialTyp::Param(param_0) ].into()
+    );
+    let mut boolean = RDTyp::new("Bool");
+    let _ = boolean.add_constructor("True", vec![]);
+    let _ = boolean.add_constructor("False", vec![]);
+    let boolean = typ::dtyp(DTyp::new(boolean), vec![].into());
+    let b_list = typ::dtyp(crate::dtyp::get("List").unwrap(), vec![boolean.clone()].into());
+    let mut adts_encs: BTreeMap<Typ, Encoder> = BTreeMap::new();
+    let fake_enc: Enc<Approx> = Enc { typ: typ::int(), n_params: 1, approxs: BTreeMap::new(), simplification: SimplificationKind::None };
+    adts_encs.insert(boolean.clone(), fake_enc.clone());
+    adts_encs.insert(b_list.clone(), fake_enc.clone());
+    let graph = ADTDependencyGraph::new(&adts_encs).unwrap();
+    let mut expected: BTreeSet<Typ> = BTreeSet::new();
+    expected.insert(boolean);
+    assert_eq!(graph.statically_simplifiable, expected);
+}
+
+#[test]
+fn test_dynamic_adt_detection() {
+    use crate::dtyp::DTyp;
+    use crate::dtyp::PartialTyp;
+    use crate::dtyp::TPrmIdx;
+    use crate::dtyp::RDTyp;
+    use crate::parse::Pos;
+
+    let dummy_pos = Pos::default();
+    let param_0: TPrmIdx = 0.into();
+    let ptyp = PartialTyp::DTyp (
+        "List".into(), dummy_pos, vec![ PartialTyp::Param(param_0) ].into()
+    );
+    let int_list = typ::dtyp(crate::dtyp::get("List").unwrap(), vec![typ::int()].into());
+
+    let mut tuple = RDTyp::new("Tuple");
+    let _ = tuple.add_constructor("tuple", vec![("first".to_string(), PartialTyp::Typ(int_list.clone())), ("second".to_string(), PartialTyp::Typ(int_list.clone()))]);
+    let tuple = typ::dtyp(DTyp::new(tuple), vec![].into());
+    let mut adts_encs: BTreeMap<Typ, Encoder> = BTreeMap::new();
+    let fake_enc: Enc<Approx> = Enc { typ: typ::int(), n_params: 1, approxs: BTreeMap::new(), simplification: SimplificationKind::None };
+    adts_encs.insert(int_list.clone(), fake_enc.clone());
+    adts_encs.insert(tuple.clone(), fake_enc.clone());
+    let graph = ADTDependencyGraph::new(&adts_encs).unwrap();
+    let mut expected: BTreeSet<Typ> = BTreeSet::new();
+    expected.insert(tuple);
+    assert_eq!(graph.dynamically_simplifiable, expected);
 }

--- a/src/absadt/catamorphism_parser.rs
+++ b/src/absadt/catamorphism_parser.rs
@@ -301,6 +301,8 @@ pub fn build_encoding_from_approx(
                     approxs: new_approxs.clone(),
                     typ: typ.clone(),
                     n_params: *approximation_degree,
+                    statically_simplified: false,
+                    dinamically_simplified: false,
                 };
                 return_encs.insert(typ.clone(), enc);
             }

--- a/src/absadt/catamorphism_parser.rs
+++ b/src/absadt/catamorphism_parser.rs
@@ -301,8 +301,7 @@ pub fn build_encoding_from_approx(
                     approxs: new_approxs.clone(),
                     typ: typ.clone(),
                     n_params: *approximation_degree,
-                    statically_simplified: false,
-                    dinamically_simplified: false,
+                    simplification: SimplificationKind::None,
                 };
                 return_encs.insert(typ.clone(), enc);
             }

--- a/src/absadt/enc.rs
+++ b/src/absadt/enc.rs
@@ -83,6 +83,25 @@ impl Approx {
             terms: vec![term::int_zero()],
         }
     }
+
+    pub fn expand_signature(
+        &mut self,
+        simplifications: &BTreeMap<Typ, usize>,
+    ) {
+        let mut new_signature = VarMap::<VarInfo>::new();
+        for old_arg in self.args.iter() {
+            let arg_approx_degree = simplifications.get(&old_arg.typ).unwrap_or(&1);
+            for degree in 0..*arg_approx_degree {
+                new_signature.push(VarInfo {
+                    name: format!("{}_{}", old_arg.name.clone(), degree,),
+                    typ: typ::int(),
+                    idx: new_signature.next_index(),
+                    active: true,
+                });
+            }
+        }
+        self.args = new_signature;
+    }
 }
 
 pub trait Approximation {
@@ -114,6 +133,8 @@ pub struct Enc<Approx> {
     pub typ: Typ,
     pub n_params: usize,
     pub approxs: BTreeMap<String, Approx>,
+    pub statically_simplified: bool,
+    pub dinamically_simplified: bool,
 }
 
 impl<Approx: std::fmt::Display> std::fmt::Display for Enc<Approx> {
@@ -172,6 +193,8 @@ impl<A: Approximation> Enc<A> {
             typ: ilist_typ,
             n_params: 1,
             approxs,
+            statically_simplified: false,
+            dinamically_simplified: false,
         }
     }
     fn get_ith_enc_rdf_name(&self, i: usize) -> String {

--- a/src/absadt/enc.rs
+++ b/src/absadt/enc.rs
@@ -124,6 +124,13 @@ impl Approximation for Approx {
     }
 }
 
+ #[derive(Debug, Clone, Copy)]
+pub enum SimplificationKind {
+    None,
+    StaticApprox,
+    DynamicApprox,
+}
+
 /// Enc is an encoding of ADT terms to integer expressions.
 ///
 /// Assumption: typ is a monomorphic type.
@@ -133,8 +140,7 @@ pub struct Enc<Approx> {
     pub typ: Typ,
     pub n_params: usize,
     pub approxs: BTreeMap<String, Approx>,
-    pub statically_simplified: bool,
-    pub dinamically_simplified: bool,
+    pub simplification: SimplificationKind,
 }
 
 impl<Approx: std::fmt::Display> std::fmt::Display for Enc<Approx> {
@@ -193,8 +199,7 @@ impl<A: Approximation> Enc<A> {
             typ: ilist_typ,
             n_params: 1,
             approxs,
-            statically_simplified: false,
-            dinamically_simplified: false,
+            simplification: SimplificationKind::None,
         }
     }
     fn get_ith_enc_rdf_name(&self, i: usize) -> String {

--- a/src/absadt/learn.rs
+++ b/src/absadt/learn.rs
@@ -29,18 +29,13 @@ impl TemplateInfo {
         Ok(())
     }
 
-    fn is_used_in_semplified_enc(&self, var_info: &VarInfo) -> bool {
+    fn is_used_in_simplified_enc(&self, var_idx: &VarIdx) -> bool {
         for (_, enc) in self.encs.iter() {
             for (_, approx) in enc.approxs.iter() {
                 match approx {
                     Template::Linear(_) => {},
-                    Template::StaticSemplification(static_approx) => {
-                        if static_approx.approx.args.contains(var_info) {
-                            return true;
-                        }
-                    }
-                    Template::Dynamicemplification(dyn_approx) =>{
-                        if dyn_approx.approx.args.contains(var_info) {
+                    Template::Simplified(approx) => {
+                        if approx.approx.args.iter().any(|var_info| *var_idx == var_info.idx) {
                             return true;
                         }
                     }
@@ -52,7 +47,7 @@ impl TemplateInfo {
 
     /// Define paramter constants
     fn define_parameters(&self, solver: &mut Solver<Parser>) -> Res<()> {
-        for var in self.parameters.iter().filter(|var_info| !self.is_used_in_semplified_enc(var_info)) {
+        for var in self.parameters.iter().filter(|var_info| !self.is_used_in_simplified_enc(&var_info.idx)) {
             solver.declare_const(&format!("v_{}", var.idx), &var.typ.to_string())?;
         }
         Ok(())
@@ -71,36 +66,42 @@ impl TemplateInfo {
         // prepare LinearApprox for each constructor
         for (typ, old_enc) in encs.iter() {
             let mut approxs = BTreeMap::new();
-            if old_enc.statically_simplified {
-                StaticApprox::new(&mut approxs, &mut variables, &old_enc);
-            } else if old_enc.dinamically_simplified {
-                DynamicApprox::new(&mut approxs, &mut variables, &old_enc);
+            match old_enc.simplification {
+                SimplificationKind::None =>
+                    Self::linear_approx(
+                        &mut approxs,
+                        &mut variables,
+                        typ,
+                        encs,
+                        n_encs,
+                        min,
+                        max,
+                        structured,
+                    ),
+                _ =>
+                    SimplifiedApprox::simplified_approx(
+                        &mut approxs,
+                        &mut variables,
+                        &old_enc,
+                        old_enc.simplification,
+                        n_encs,
+                    ).unwrap(),
             }
-            else {
-                Self::linear_apporx(
-                    &mut approxs,
-                    &mut variables,
-                    typ,
-                    encs,
-                    n_encs,
-                    min,
-                    max,
-                    structured,
-                );
-            }
-            let statically_simplified = encs.get(typ).unwrap().statically_simplified;
-            let dinamically_simplified = encs.get(typ).unwrap().dinamically_simplified;
-            let n_params = if statically_simplified || dinamically_simplified {
-                old_enc.n_params
-            } else {
-                n_encs
+            let n_params = match old_enc.simplification {
+                SimplificationKind::StaticApprox => old_enc.n_params,
+                SimplificationKind::DynamicApprox => {
+                    match approxs.values().next().unwrap() {
+                        Template::Simplified(template) => template.approx.terms.len(),
+                        Template::Linear(_) => panic!(),
+                    }
+                },
+                SimplificationKind::None => n_encs,
             };
             let enc = Enc {
                 approxs,
                 typ: typ.clone(),
                 n_params,
-                statically_simplified,
-                dinamically_simplified,
+                simplification: old_enc.simplification,
             };
             new_encs.insert(typ.clone(), enc);
         }
@@ -111,7 +112,7 @@ impl TemplateInfo {
         }
     }
 
-    fn linear_apporx(
+    fn linear_approx(
         approxs: &mut BTreeMap<String, Template>,
         mut variables: &mut VarInfos,
         typ: &Typ,
@@ -130,16 +131,19 @@ impl TemplateInfo {
             for (sel, ty) in ty.selectors_of(constr).unwrap().iter() {
                 let ty = ty.to_type(Some(prms)).unwrap();
                 let is_recursive = encs.get(&ty).is_some();
-                let n_arg = if is_recursive {
-                    if encs.get(&ty).is_some_and(
-                        |v| v.statically_simplified || v.dinamically_simplified
-                    ) {
-                        encs.get(&ty).unwrap().n_params
-                    } else{
-                        n_encs
+                let n_arg = match encs.get(&ty) {
+                    Some(enc) => {
+                        if matches!(
+                            enc.simplification,
+                            SimplificationKind::StaticApprox |
+                            SimplificationKind::DynamicApprox
+                        ) {
+                            enc.n_params
+                        } else {
+                            n_encs
+                        }
                     }
-                } else {
-                    1
+                    None => 1,
                 };
                 if !is_recursive {
                     assert!(ty.is_int());
@@ -348,16 +352,14 @@ pub struct LearnCtx<'a> {
 
 enum Template {
     Linear(LinearApprox),
-    StaticSemplification(StaticApprox),
-    Dynamicemplification(DynamicApprox),
+    Simplified(SimplifiedApprox),
 }
 
 impl Approximation for Template {
     fn apply(&self, arg_terms: &[Term]) -> Vec<Term> {
         match self {
             Template::Linear(approx) => approx.apply(arg_terms),
-            Template::StaticSemplification(approx) => approx.apply(arg_terms),
-            Template::Dynamicemplification(approx) => approx.apply(arg_terms),
+            Template::Simplified(approx) => approx.apply(arg_terms),
         }
     }
 }
@@ -366,15 +368,13 @@ impl Template {
     fn instantiate(&self, model: &Model) -> Approx {
         match self {
             Template::Linear(approx) => approx.instantiate(model),
-            Template::StaticSemplification(approx) => approx.instantiate(),
-            Template::Dynamicemplification(approx) => approx.instantiate(),
+            Template::Simplified(approx) => approx.instantiate(),
         }
     }
     fn constraint(&self) -> Option<Term> {
         match self {
             Template::Linear(approx) => approx.constraint(),
-            Template::StaticSemplification(_) => None,
-            Template::Dynamicemplification(_) => None,
+            Template::Simplified(_) => None,
         }
     }
     fn param_range(&self) -> Option<(i64, i64)> {
@@ -386,8 +386,7 @@ impl Template {
                     None
                 }
             }
-            Template::StaticSemplification(_) => None,
-            Template::Dynamicemplification(_) => None,
+            Template::Simplified(_) => None,
         }
     }
 }
@@ -560,8 +559,60 @@ impl LinearApprox {
     }
 }
 
-trait SimplifiedApproximation {
-    fn shift_index(new_args: &VarInfos, old_args: &VarInfos, old_terms: &Vec<Term>) -> Vec<Term> {
+struct SimplifiedApprox {
+    /// Existing approx
+    approx: Approx,
+}
+
+impl SimplifiedApprox {
+    fn simplified_approx (
+        new_approxs: &mut BTreeMap<String, Template>,
+        variables: &mut VarInfos,
+        old_approx: &Enc<Approx>,
+        kind: SimplificationKind,
+        approx: usize,
+    ) -> Res<()> {
+        let constructors = &old_approx.typ.dtyp_inspect().unwrap().0.news;
+        let mut dyn_constr_discriminator = if constructors.len() > 1 {0} else {-1};
+        for constr_name in constructors.keys() {
+            let mut approx_args = VarInfos::new();
+            Self::create_vars_info(variables, &mut approx_args, old_approx, constr_name, kind, approx)?;
+            let old_approx_ref = old_approx.approxs.get(constr_name).unwrap();
+            let terms = match kind {
+                SimplificationKind::StaticApprox =>
+                    Self::shift_body_indices(
+                        &approx_args,
+                        &old_approx_ref.args,
+                        &old_approx_ref.terms
+                    ),
+                SimplificationKind::DynamicApprox =>
+                    Self::new_dynamic_term(
+                        &approx_args,
+                        dyn_constr_discriminator
+                    ),
+                SimplificationKind::None => Err(Error::from_kind(ErrorKind::Msg(format!(
+                    "I was expecting an a simplifiable approximation"
+                ))))?,
+            };
+            dyn_constr_discriminator = if matches!(kind, SimplificationKind::DynamicApprox) {
+                dyn_constr_discriminator + 1
+            } else {0};
+            new_approxs.insert(
+                constr_name.clone(),
+                Template::Simplified(
+                    Self {
+                        approx: Approx {
+                            args: approx_args,
+                            terms,
+                        },
+                    }
+                ),
+            );
+        }
+        Ok(())
+    }
+    
+    fn shift_body_indices(new_args: &VarInfos, old_args: &VarInfos, old_terms:  &Vec<Term>) -> Vec<Term> {
         let mut new_terms = Vec::new();
         for term in old_terms.iter() {
             match term.get() {
@@ -588,25 +639,63 @@ trait SimplifiedApproximation {
         new_terms
     }
 
-    fn create_vars_info (variables: &mut VarInfos,approx_args: &mut VarInfos, old_approx: &Enc<Approx>, constr_name: &str, ) {
-        for idx in 0..old_approx.approxs.get(constr_name).unwrap().args.len() {
+    fn new_dynamic_term(new_args: &VarInfos, constructor_discriminator: isize) -> Vec<Term> {
+        let mut new_terms = Vec::new();
+        if constructor_discriminator >= 0 {
+            new_terms.push(term::int(constructor_discriminator));
+        }
+        for arg in new_args.iter() {
+            new_terms.push(term::int_var(arg.idx));
+        }
+        new_terms
+    }
+
+    fn create_vars_info (
+        variables: &mut VarInfos,
+        approx_args: &mut VarInfos,
+        old_approx: &Enc<Approx>,
+        constr_name: &str,
+        kind: SimplificationKind,
+        degree: usize,
+    ) -> Res<()> {
+        let n_vars = match kind {
+            SimplificationKind::StaticApprox => {
+                Ok(old_approx.approxs.get(constr_name).unwrap().args.len())
+            }
+            SimplificationKind::DynamicApprox => {
+                let mut sum = 0;
+                if let Some((dtyp, generic_rtyps)) = old_approx.typ.dtyp_inspect() {
+                    let mut cache = BTreeMap::<typ::RTyp, usize>::new();
+                    for (_, arg_ptyp) in dtyp.news.get(constr_name).unwrap().iter() {
+                        let arg_rtyp = arg_ptyp.to_type(Some(generic_rtyps)).unwrap();
+                        arg_rtyp.compute_approximation_degree(&mut cache, degree)?;
+                        sum += cache.get(arg_rtyp.get()).unwrap();
+                    }
+                }
+                Ok(sum)
+            }
+            SimplificationKind::None => {
+                Err(Error::from_kind(ErrorKind::Msg(format!(
+                    "I was expecting an a simplifiable approximation"
+                ))))
+            }
+        }?;
+        for idx in 0..n_vars {
             let next_index = variables.next_index();
             let info =
                 VarInfo::new(format!("arg-{}-{idx}", constr_name), typ::int(), next_index);
             variables.push(info.clone());
             approx_args.push(info);
         }
+        Ok(())
+    }
+
+    fn instantiate(&self) -> Approx {
+        self.approx.clone()
     }
 }
 
-struct StaticApprox {
-    /// Existing approx
-    approx: Approx,
-}
-
-impl SimplifiedApproximation for StaticApprox {}
-
-impl Approximation for StaticApprox {
+impl Approximation for SimplifiedApprox {
     fn apply(&self, arg_terms: &[Term]) -> Vec<Term> {
         let subst_map: VarHMap<_> = self
             .approx
@@ -620,88 +709,6 @@ impl Approximation for StaticApprox {
             res.push(term.subst(&subst_map).0);
         }
         res
-    }
-}
-
-impl StaticApprox {
-    fn new(
-        new_approxs: &mut BTreeMap<String, Template>,
-        variables: &mut VarInfos,
-        old_approx: &Enc<Approx>,
-    ) {
-        for constr_name in old_approx.typ.dtyp_inspect().unwrap().0.news.keys() {
-            let mut approx_args = VarInfos::new();
-            Self::create_vars_info(variables, &mut approx_args, old_approx, constr_name);
-            let old_approx_ref = old_approx.approxs.get(constr_name).unwrap();
-            let terms =
-                Self::shift_index(&approx_args, &old_approx_ref.args, &old_approx_ref.terms);
-            new_approxs.insert(
-                constr_name.clone(),
-                Template::StaticSemplification(Self {
-                    approx: Approx {
-                        args: approx_args,
-                        terms,
-                    },
-                }),
-            );
-        }
-    }
-
-    fn instantiate(&self) -> Approx {
-        self.approx.clone()
-    }
-}
-
-struct DynamicApprox {
-    /// Existing approx
-    approx: Approx,
-}
-
-impl SimplifiedApproximation for DynamicApprox {}
-
-impl Approximation for DynamicApprox {
-    fn apply(&self, arg_terms: &[Term]) -> Vec<Term> {
-        let subst_map: VarHMap<_> = self
-            .approx
-            .args
-            .iter()
-            .map(|x| x.idx)
-            .zip(arg_terms.iter().cloned())
-            .collect();
-        let mut res = Vec::with_capacity(self.approx.terms.len());
-        for term in self.approx.terms.iter() {
-            res.push(term.subst(&subst_map).0);
-        }
-        res
-    }
-}
-
-impl DynamicApprox {
-    fn new (
-        new_approxs: &mut BTreeMap<String, Template>,
-        variables: &mut VarInfos,
-        old_approx: &Enc<Approx>,
-    ) {
-        for constr_name in old_approx.typ.dtyp_inspect().unwrap().0.news.keys() {
-            let mut approx_args = VarInfos::new();
-            Self::create_vars_info(variables, &mut approx_args, old_approx, constr_name);
-            let old_approx_ref = old_approx.approxs.get(constr_name).unwrap();
-            let terms =
-                Self::shift_index(&approx_args, &old_approx_ref.args, &old_approx_ref.terms);
-            new_approxs.insert(
-                constr_name.clone(),
-                Template::Dynamicemplification(Self {
-                    approx: Approx {
-                        args: approx_args,
-                        terms,
-                    },
-                }),
-            );
-        }
-    }
-
-    fn instantiate(&self) -> Approx {
-        self.approx.clone()
     }
 }
 
@@ -716,8 +723,7 @@ impl Enc<Template> {
             approxs,
             typ: self.typ.clone(),
             n_params: self.n_params,
-            statically_simplified: self.statically_simplified,
-            dinamically_simplified: self.dinamically_simplified,
+            simplification: self.simplification,
         }
     }
 }

--- a/src/absadt/learn.rs
+++ b/src/absadt/learn.rs
@@ -28,9 +28,31 @@ impl TemplateInfo {
 
         Ok(())
     }
+
+    fn is_used_in_semplified_enc(&self, var_info: &VarInfo) -> bool {
+        for (_, enc) in self.encs.iter() {
+            for (_, approx) in enc.approxs.iter() {
+                match approx {
+                    Template::Linear(_) => {},
+                    Template::StaticSemplification(static_approx) => {
+                        if static_approx.approx.args.contains(var_info) {
+                            return true;
+                        }
+                    }
+                    Template::Dynamicemplification(dyn_approx) =>{
+                        if dyn_approx.approx.args.contains(var_info) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
     /// Define paramter constants
     fn define_parameters(&self, solver: &mut Solver<Parser>) -> Res<()> {
-        for var in self.parameters.iter() {
+        for var in self.parameters.iter().filter(|var_info| !self.is_used_in_semplified_enc(var_info)) {
             solver.declare_const(&format!("v_{}", var.idx), &var.typ.to_string())?;
         }
         Ok(())
@@ -47,55 +69,38 @@ impl TemplateInfo {
         let mut new_encs = BTreeMap::new();
 
         // prepare LinearApprox for each constructor
-        for typ in encs.keys() {
+        for (typ, old_enc) in encs.iter() {
             let mut approxs = BTreeMap::new();
-            for constr in typ.dtyp_inspect().unwrap().0.news.keys() {
-                // for each constructor, we prepare an approx
-                let (ty, prms) = typ.dtyp_inspect().unwrap();
-                // prepare function arguments
-                let mut approx_args = VarInfos::new();
-                let mut arg_components: Vec<Option<usize>> = Vec::new();
-                for (sel, ty) in ty.selectors_of(constr).unwrap().iter() {
-                    let ty = ty.to_type(Some(prms)).unwrap();
-                    let is_recursive = encs.get(&ty).is_some();
-                    let n_arg = if is_recursive { n_encs } else { 1 };
-                    if !is_recursive {
-                        assert!(ty.is_int());
-                    }
-                    for i in 0..n_arg {
-                        let next_index = variables.next_index();
-                        let info = VarInfo::new(
-                            format!("arg-{}-{}", sel, i),
-                            typ::int(),
-                            next_index,
-                        );
-                        variables.push(info.clone());
-                        approx_args.push(info);
-                        if is_recursive {
-                            arg_components.push(Some(i));
-                        } else {
-                            arg_components.push(None);
-                        }
-                    }
-                }
-                // create a LinearApprox
-                approxs.insert(
-                    constr.to_string(),
-                    Template::Linear(LinearApprox::new(
-                        approx_args,
-                        n_encs,
-                        &mut variables,
-                        min,
-                        max,
-                        arg_components,
-                        structured,
-                    )),
+            if old_enc.statically_simplified {
+                StaticApprox::new(&mut approxs, &mut variables, &old_enc);
+            } else if old_enc.dinamically_simplified {
+                DynamicApprox::new(&mut approxs, &mut variables, &old_enc);
+            }
+            else {
+                Self::linear_apporx(
+                    &mut approxs,
+                    &mut variables,
+                    typ,
+                    encs,
+                    n_encs,
+                    min,
+                    max,
+                    structured,
                 );
             }
+            let statically_simplified = encs.get(typ).unwrap().statically_simplified;
+            let dinamically_simplified = encs.get(typ).unwrap().dinamically_simplified;
+            let n_params = if statically_simplified || dinamically_simplified {
+                old_enc.n_params
+            } else {
+                n_encs
+            };
             let enc = Enc {
                 approxs,
                 typ: typ.clone(),
-                n_params: n_encs,
+                n_params,
+                statically_simplified,
+                dinamically_simplified,
             };
             new_encs.insert(typ.clone(), enc);
         }
@@ -103,6 +108,67 @@ impl TemplateInfo {
         TemplateInfo {
             parameters: variables,
             encs: new_encs,
+        }
+    }
+
+    fn linear_apporx(
+        approxs: &mut BTreeMap<String, Template>,
+        mut variables: &mut VarInfos,
+        typ: &Typ,
+        encs: &BTreeMap<Typ, Encoder>,
+        n_encs: usize,
+        min: Option<i64>,
+        max: Option<i64>,
+        structured: bool,
+    ) {
+        for constr in typ.dtyp_inspect().unwrap().0.news.keys() {
+            // for each constructor, we prepare an approx
+            let (ty, prms) = typ.dtyp_inspect().unwrap();
+            // prepare function arguments
+            let mut approx_args = VarInfos::new();
+            let mut arg_components: Vec<Option<usize>> = Vec::new();
+            for (sel, ty) in ty.selectors_of(constr).unwrap().iter() {
+                let ty = ty.to_type(Some(prms)).unwrap();
+                let is_recursive = encs.get(&ty).is_some();
+                let n_arg = if is_recursive {
+                    if encs.get(&ty).is_some_and(
+                        |v| v.statically_simplified || v.dinamically_simplified
+                    ) {
+                        encs.get(&ty).unwrap().n_params
+                    } else{
+                        n_encs
+                    }
+                } else {
+                    1
+                };
+                if !is_recursive {
+                    assert!(ty.is_int());
+                }
+                for i in 0..n_arg {
+                    let next_index = variables.next_index();
+                    let info = VarInfo::new(format!("arg-{}-{}", sel, i), typ::int(), next_index);
+                    variables.push(info.clone());
+                    approx_args.push(info);
+                    if is_recursive {
+                        arg_components.push(Some(i));
+                    } else {
+                        arg_components.push(None);
+                    }
+                }
+            }
+            // create a LinearApprox
+            approxs.insert(
+                constr.to_string(),
+                Template::Linear(LinearApprox::new(
+                    approx_args,
+                    n_encs,
+                    &mut variables,
+                    min,
+                    max,
+                    arg_components,
+                    structured,
+                )),
+            );
         }
     }
 
@@ -282,12 +348,16 @@ pub struct LearnCtx<'a> {
 
 enum Template {
     Linear(LinearApprox),
+    StaticSemplification(StaticApprox),
+    Dynamicemplification(DynamicApprox),
 }
 
 impl Approximation for Template {
     fn apply(&self, arg_terms: &[Term]) -> Vec<Term> {
         match self {
             Template::Linear(approx) => approx.apply(arg_terms),
+            Template::StaticSemplification(approx) => approx.apply(arg_terms),
+            Template::Dynamicemplification(approx) => approx.apply(arg_terms),
         }
     }
 }
@@ -296,11 +366,15 @@ impl Template {
     fn instantiate(&self, model: &Model) -> Approx {
         match self {
             Template::Linear(approx) => approx.instantiate(model),
+            Template::StaticSemplification(approx) => approx.instantiate(),
+            Template::Dynamicemplification(approx) => approx.instantiate(),
         }
     }
     fn constraint(&self) -> Option<Term> {
         match self {
             Template::Linear(approx) => approx.constraint(),
+            Template::StaticSemplification(_) => None,
+            Template::Dynamicemplification(_) => None,
         }
     }
     fn param_range(&self) -> Option<(i64, i64)> {
@@ -312,6 +386,8 @@ impl Template {
                     None
                 }
             }
+            Template::StaticSemplification(_) => None,
+            Template::Dynamicemplification(_) => None,
         }
     }
 }
@@ -484,6 +560,151 @@ impl LinearApprox {
     }
 }
 
+trait SimplifiedApproximation {
+    fn shift_index(new_args: &VarInfos, old_args: &VarInfos, old_terms: &Vec<Term>) -> Vec<Term> {
+        let mut new_terms = Vec::new();
+        for term in old_terms.iter() {
+            match term.get() {
+                RTerm::Cst(_) => new_terms.push(term.clone()),
+                RTerm::Var(typ, old_idx) => {
+                    let old_pos = old_args
+                        .iter()
+                        .enumerate()
+                        .rfind(|(_, old_var)| *old_var.idx == **old_idx)
+                        .unwrap()
+                        .0;
+                    let new_idx = new_args
+                        .iter()
+                        .enumerate()
+                        .rfind(|(pos, _)| *pos == old_pos)
+                        .unwrap()
+                        .1
+                        .idx;
+                    new_terms.push(RTerm::Var(typ.clone(), new_idx).to_hcons());
+                }
+                _ => {}
+            }
+        }
+        new_terms
+    }
+
+    fn create_vars_info (variables: &mut VarInfos,approx_args: &mut VarInfos, old_approx: &Enc<Approx>, constr_name: &str, ) {
+        for idx in 0..old_approx.approxs.get(constr_name).unwrap().args.len() {
+            let next_index = variables.next_index();
+            let info =
+                VarInfo::new(format!("arg-{}-{idx}", constr_name), typ::int(), next_index);
+            variables.push(info.clone());
+            approx_args.push(info);
+        }
+    }
+}
+
+struct StaticApprox {
+    /// Existing approx
+    approx: Approx,
+}
+
+impl SimplifiedApproximation for StaticApprox {}
+
+impl Approximation for StaticApprox {
+    fn apply(&self, arg_terms: &[Term]) -> Vec<Term> {
+        let subst_map: VarHMap<_> = self
+            .approx
+            .args
+            .iter()
+            .map(|x| x.idx)
+            .zip(arg_terms.iter().cloned())
+            .collect();
+        let mut res = Vec::with_capacity(self.approx.terms.len());
+        for term in self.approx.terms.iter() {
+            res.push(term.subst(&subst_map).0);
+        }
+        res
+    }
+}
+
+impl StaticApprox {
+    fn new(
+        new_approxs: &mut BTreeMap<String, Template>,
+        variables: &mut VarInfos,
+        old_approx: &Enc<Approx>,
+    ) {
+        for constr_name in old_approx.typ.dtyp_inspect().unwrap().0.news.keys() {
+            let mut approx_args = VarInfos::new();
+            Self::create_vars_info(variables, &mut approx_args, old_approx, constr_name);
+            let old_approx_ref = old_approx.approxs.get(constr_name).unwrap();
+            let terms =
+                Self::shift_index(&approx_args, &old_approx_ref.args, &old_approx_ref.terms);
+            new_approxs.insert(
+                constr_name.clone(),
+                Template::StaticSemplification(Self {
+                    approx: Approx {
+                        args: approx_args,
+                        terms,
+                    },
+                }),
+            );
+        }
+    }
+
+    fn instantiate(&self) -> Approx {
+        self.approx.clone()
+    }
+}
+
+struct DynamicApprox {
+    /// Existing approx
+    approx: Approx,
+}
+
+impl SimplifiedApproximation for DynamicApprox {}
+
+impl Approximation for DynamicApprox {
+    fn apply(&self, arg_terms: &[Term]) -> Vec<Term> {
+        let subst_map: VarHMap<_> = self
+            .approx
+            .args
+            .iter()
+            .map(|x| x.idx)
+            .zip(arg_terms.iter().cloned())
+            .collect();
+        let mut res = Vec::with_capacity(self.approx.terms.len());
+        for term in self.approx.terms.iter() {
+            res.push(term.subst(&subst_map).0);
+        }
+        res
+    }
+}
+
+impl DynamicApprox {
+    fn new (
+        new_approxs: &mut BTreeMap<String, Template>,
+        variables: &mut VarInfos,
+        old_approx: &Enc<Approx>,
+    ) {
+        for constr_name in old_approx.typ.dtyp_inspect().unwrap().0.news.keys() {
+            let mut approx_args = VarInfos::new();
+            Self::create_vars_info(variables, &mut approx_args, old_approx, constr_name);
+            let old_approx_ref = old_approx.approxs.get(constr_name).unwrap();
+            let terms =
+                Self::shift_index(&approx_args, &old_approx_ref.args, &old_approx_ref.terms);
+            new_approxs.insert(
+                constr_name.clone(),
+                Template::Dynamicemplification(Self {
+                    approx: Approx {
+                        args: approx_args,
+                        terms,
+                    },
+                }),
+            );
+        }
+    }
+
+    fn instantiate(&self) -> Approx {
+        self.approx.clone()
+    }
+}
+
 impl Enc<Template> {
     fn instantiate(&self, model: &Model) -> Encoder {
         let mut approxs = BTreeMap::new();
@@ -495,6 +716,8 @@ impl Enc<Template> {
             approxs,
             typ: self.typ.clone(),
             n_params: self.n_params,
+            statically_simplified: self.statically_simplified,
+            dinamically_simplified: self.dinamically_simplified,
         }
     }
 }

--- a/src/dtyp.rs
+++ b/src/dtyp.rs
@@ -134,28 +134,19 @@ pub enum PartialTyp {
 }
 
 impl PartialTyp {
-    pub fn get_adt_name(&self) -> Option<String> {
-        match self {
-            PartialTyp::DTyp(name, _, _) => Some(name.clone()),
-            _ => None,
-        }
-    }
-
-    pub fn get_adt_args(&self) -> Option<Vec<&PartialTyp>> {
-        match self {
-            PartialTyp::DTyp(_, _, args) => Some(args.iter().map(|arg| arg).collect()),
-            _ => None,
-        }
-    }
-
     /// Returns the approximation degree of the current [`PartialTyp`]
     /// as a [`usize`].
     ///
+    /// The current [`PartialTyp`] is used as an argument in a ADT constructor,
+    /// in order to simplify that ADT this function compute the known
+    /// approximation degree for the current [`PartialTyp`].
+    ///
     /// # Arguments
     ///
-    /// * `generic_rtyps` - The map  with all the concrete types for the paramters.
-    /// * `system_adts` - The set of all the known ADT types in the system.
-    /// * `cache` - A map of the ADTs insepcted so far.
+    /// * `generic_rtyps` - The map with all the concrete types for the
+    ///   paramters.
+    /// * `cache` - The map of the ADTs insepcted so far.
+    /// * `degree` - The approximation degree currently in use.
     ///
     /// # Returns
     ///
@@ -163,33 +154,37 @@ impl PartialTyp {
     pub fn degree_of_arg(
         &self,
         generic_rtyps: &TPrmMap<Typ>,
-        system_adts: &BTreeSet<Typ>,
         cache: &mut BTreeMap<typ::RTyp, usize>,
-    ) -> usize {
+        degree: usize,
+    ) -> Res<usize> {
         match self {
-        PartialTyp::Typ(arg_rtyp) => match arg_rtyp.get() {
-            typ::RTyp::Int => 1,
-            typ::RTyp::DTyp { .. } => {
-                arg_rtyp.ensure_cached(system_adts, cache);
-                *cache.get(arg_rtyp.get()).unwrap_or(&0)
-            }
-            _ => 0,
-        },
+            PartialTyp::Typ(arg_rtyp) => match arg_rtyp.get() {
+                typ::RTyp::Int => Ok(1),
+                typ::RTyp::DTyp { .. } => {
+                    arg_rtyp.ensure_cached(cache, degree)?;
+                    Ok(*cache.get(arg_rtyp.get()).unwrap())
+                }
+                _ => Err(Error::from_kind(ErrorKind::Msg(format!(
+                    "{self} is not an integer or a Datatype"
+                )))),
+            },
             PartialTyp::DTyp(_, _, _) => {
                 match self.to_type(Some(generic_rtyps)) {
                     Ok(arg_rtyp) => {
-                        arg_rtyp.ensure_cached(system_adts, cache);
-                    *cache.get(&arg_rtyp).unwrap_or(&0)
+                        arg_rtyp.ensure_cached(cache, degree)?;
+                    Ok(*cache.get(&arg_rtyp).unwrap())
                     }
-                    Err(_) => 1,
+                    Err((_, msg)) => Err(Error::from_kind(ErrorKind::Msg(msg))),
                 }
             }
             PartialTyp::Param(idx) => {
                 let param_rtyp = generic_rtyps[*idx].get();
-                param_rtyp.ensure_cached(system_adts, cache);
-                *cache.get(param_rtyp).unwrap_or(&0)
+                param_rtyp.ensure_cached(cache, degree)?;
+                Ok(*cache.get(param_rtyp).unwrap())
             }
-            _ => 0,
+            _ => Err(Error::from_kind(ErrorKind::Msg(format!(
+                "{self} partial type not supported"
+            )))),
         }
     }
 }
@@ -1513,4 +1508,28 @@ fn dtyp_write_dec() {
 ) )\n\
         "
     )
+}
+
+#[test]
+fn dtyp_arg_degree() -> Res<()> {
+    let mut dtyp_tup_int = RDTyp::new("tup_int");
+    dtyp_tup_int.add_constructor(
+        "tup",
+        vec![
+            ("first".to_string(), PartialTyp::Typ(typ::int())),
+            ("second".to_string(), PartialTyp::Typ(typ::int())),
+            ("third".to_string(), PartialTyp::Typ(typ::int())),
+        ],
+    )?;
+    let typ_tup_int = typ::dtyp(DTyp::new(dtyp_tup_int), vec![].into());
+    let ptyp = PartialTyp::Typ(typ_tup_int.clone());
+    assert_eq!(
+        3,
+        ptyp.degree_of_arg(
+            &TPrmMap::new(),
+            &mut BTreeMap::<typ::RTyp, usize>::new(),
+            1
+        )?
+    );
+    Ok(())
 }

--- a/src/dtyp.rs
+++ b/src/dtyp.rs
@@ -133,6 +133,67 @@ pub enum PartialTyp {
     Param(TPrmIdx),
 }
 
+impl PartialTyp {
+    pub fn get_adt_name(&self) -> Option<String> {
+        match self {
+            PartialTyp::DTyp(name, _, _) => Some(name.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn get_adt_args(&self) -> Option<Vec<&PartialTyp>> {
+        match self {
+            PartialTyp::DTyp(_, _, args) => Some(args.iter().map(|arg| arg).collect()),
+            _ => None,
+        }
+    }
+
+    /// Returns the approximation degree of the current [`PartialTyp`]
+    /// as a [`usize`].
+    ///
+    /// # Arguments
+    ///
+    /// * `generic_rtyps` - The map  with all the concrete types for the paramters.
+    /// * `system_adts` - The set of all the known ADT types in the system.
+    /// * `cache` - A map of the ADTs insepcted so far.
+    ///
+    /// # Returns
+    ///
+    /// A [`usize`] representing the initial approximation degree of [`PartialTyp`].
+    pub fn degree_of_arg(
+        &self,
+        generic_rtyps: &TPrmMap<Typ>,
+        system_adts: &BTreeSet<Typ>,
+        cache: &mut BTreeMap<typ::RTyp, usize>,
+    ) -> usize {
+        match self {
+        PartialTyp::Typ(arg_rtyp) => match arg_rtyp.get() {
+            typ::RTyp::Int => 1,
+            typ::RTyp::DTyp { .. } => {
+                arg_rtyp.ensure_cached(system_adts, cache);
+                *cache.get(arg_rtyp.get()).unwrap_or(&0)
+            }
+            _ => 0,
+        },
+            PartialTyp::DTyp(_, _, _) => {
+                match self.to_type(Some(generic_rtyps)) {
+                    Ok(arg_rtyp) => {
+                        arg_rtyp.ensure_cached(system_adts, cache);
+                    *cache.get(&arg_rtyp).unwrap_or(&0)
+                    }
+                    Err(_) => 1,
+                }
+            }
+            PartialTyp::Param(idx) => {
+                let param_rtyp = generic_rtyps[*idx].get();
+                param_rtyp.ensure_cached(system_adts, cache);
+                *cache.get(param_rtyp).unwrap_or(&0)
+            }
+            _ => 0,
+        }
+    }
+}
+
 impl From<Typ> for PartialTyp {
     fn from(typ: Typ) -> Self {
         PartialTyp::Typ(typ)

--- a/src/info.rs
+++ b/src/info.rs
@@ -7,7 +7,7 @@ use rsmt2::print::{Sort2Smt, Sym2Smt};
 use crate::common::*;
 
 /// Variable info for clauses or function definitions.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct VarInfo {
     /// Variable's name.
     pub name: String,

--- a/src/info.rs
+++ b/src/info.rs
@@ -7,7 +7,7 @@ use rsmt2::print::{Sort2Smt, Sym2Smt};
 use crate::common::*;
 
 /// Variable info for clauses or function definitions.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VarInfo {
     /// Variable's name.
     pub name: String,

--- a/src/term/typ.rs
+++ b/src/term/typ.rs
@@ -171,52 +171,43 @@ impl RTyp {
         }
     }
 
-    pub fn dtyp_dependencies(
+    /// Returns the set of depth 1 dependencies for the current [`RTyp`].
+    ///
+    /// *depth 1 dependencies* encompasses only the types used in the [`RTyp`]
+    /// constructors.
+    ///
+    /// # Returns
+    ///
+    /// A [`BTreeSet<Typ>`] containing all the types present in the current
+    /// [`RTyp`] constructors.
+    ///
+    /// # Example
+    /// Give the following type as the current [`RTyp`]
+    /// ```text
+    /// (declare-datatypes ((list 0)) (((nil ) (cons  (head Nat) (tail list)))))
+    /// ```
+    /// The method returns
+    /// ```text
+    /// {"list", "Nat"}
+    /// ```
+    pub fn dtyp_typs_in_news(
         &self,
-        system_adts: &BTreeSet<Typ>,
     ) -> Res<BTreeSet<Typ>> {
         let mut dependencies = BTreeSet::new();
         if let Some((dtyp, generic_rtyps)) = self.dtyp_inspect() {
             for (_, args) in dtyp.news.iter() {
                 for (_, arg_ptyp) in args.iter() {
-                    match arg_ptyp {
-                        PartialTyp::Typ(rtyp) => match rtyp.get() {
-                            RTyp::DTyp { dtyp: _, prms: _ } => {
-                                dependencies.insert(rtyp.clone());
-                            }
-                            RTyp::Int => {}
-                            _ => {
-                                return Err(Error::from_kind(ErrorKind::Msg(format!(
-                                    "I was expecting an ADT or an Int, found {rtyp}"
-                                ))));
-                            }
-                        },
-                        PartialTyp::DTyp(_, _, _) => {
-                            if let Ok(arg_rtyp) = arg_ptyp.to_type(Some(generic_rtyps)) {
-                                if let Some(dep_typ) = system_adts.get(&arg_rtyp) {
-                                    dependencies.insert(dep_typ.clone());
-                                }
-                            }
+                    let arg_rtyp = arg_ptyp.to_type(Some(generic_rtyps)).unwrap();
+                    match arg_rtyp.get() {
+                        RTyp::DTyp { dtyp: _, prms: _ } => {
+                            dependencies.insert(arg_rtyp.clone());
                         }
-                        PartialTyp::Param(_) => {}
+                        RTyp::Int => {}
                         _ => {
                             return Err(Error::from_kind(ErrorKind::Msg(format!(
-                                "I was expecting a concrete type or a generic, found {arg_ptyp} in {dtyp}"
+                                "I was expecting an ADT or an Int, found {arg_rtyp}"
                             ))));
                         }
-                    }
-                }
-            }
-            for generic_rtyp in generic_rtyps.iter() {
-                match generic_rtyp.get() {
-                    RTyp::DTyp { dtyp: _, prms: _ } => {
-                        dependencies.insert(generic_rtyp.clone());
-                    }
-                    RTyp::Int => {}
-                    _ => {
-                        return Err(Error::from_kind(ErrorKind::Msg(format!(
-                            "I was expecting either an ADT or an Int, found {generic_rtyp}"
-                        ))));
                     }
                 }
             }
@@ -224,12 +215,12 @@ impl RTyp {
         Ok(dependencies)
     }
 
-    pub fn is_recursive(&self, system_adts: &BTreeSet<Typ>,) -> Res<bool> {
+    pub fn is_recursive(&self,) -> Res<bool> {
         let mut stack = vec![self.clone()];
         let mut already_visted = BTreeSet::new();
         while let Some(typ) = stack.pop() {
             already_visted.insert(typ.clone());
-            for dep in typ.dtyp_dependencies(system_adts)?.iter() {
+            for dep in typ.dtyp_typs_in_news()?.iter() {
                 if dep.get() == self {
                     return Ok(true);
                 }
@@ -246,60 +237,61 @@ impl RTyp {
     ///
     /// # Arguments
     ///
-    /// * `system_adts` - The set of all the known ADT types in the system.
-    /// * `cache` - A map of the ADTs insepcted so far.
+    /// * `cache` - A [`BTreeMap<Self, usize>`] of the ADTs insepcted so far.
+    /// * `degree` - A [`usize`] containing the current approximation degree in
+    ///   use
     ///
     /// # Returns
     ///
-    /// A [`usize`] representing the initial approximation degree of [`RTyp`].
+    /// A [`BTreeMap<Self, usize>`] called `cache` containing the initial
+    /// approximation degree of [`RTyp`].
     pub fn compute_approximation_degree(
         &self,
-        system_adts: &BTreeSet<Typ>,
         cache: &mut BTreeMap<Self, usize>,
-    ) {
+        degree: usize,
+    ) -> Res<()> {
         if cache.contains_key(self) {
-            return;
+            return Ok(());
         }
-
-        if self.is_recursive(system_adts).is_ok_and(|v| v) {
-            cache.insert(self.clone(), 1);
-            return;
+        let approx_degree = if self.is_recursive()? {
+            degree
         }
-
-        let Some((dtyp, generic_rtyps)) = self.dtyp_inspect() else {
-            cache.insert(self.clone(), 1);
-            return;
+        else if let Some((dtyp, generic_rtyps)) = self.dtyp_inspect() {
+            let constructor_degree = dtyp
+                .news
+                .iter()
+                .map(|(_, args)| {
+                    args.iter()
+                        .map(|(_, arg_ptyp)| arg_ptyp.degree_of_arg(generic_rtyps, cache, degree))
+                        .sum::<Res<usize>>()
+                })
+                .collect::<Res<Vec<usize>>>()?
+                .into_iter()
+                .max()
+                .unwrap();
+                                 // Constructors discriminator
+            constructor_degree + usize::from(dtyp.news.len() > 1)
+        } else {
+            1
         };
 
-        let constructor_degree = dtyp
-            .news
-            .iter()
-            .map(|(_, args)| {
-                args.iter()
-                    .map(|(_, arg_ptyp)| arg_ptyp.degree_of_arg(generic_rtyps, system_adts, cache))
-                    .sum::<usize>()
-            })
-            .max()
-            .unwrap_or(0);
+        cache.insert(self.clone(), approx_degree);
 
-        // Need one extra digit to discriminate between multiple constructors.
-        let discriminant_bit = if dtyp.news.len() > 1 { 1 } else { 0 };
-
-        cache.insert(self.clone(), constructor_degree + discriminant_bit);
+        Ok(())
     }
 
     /// Ensures [`RTtyp`] has an entry in `cache`, recursing if necessary.
-    pub(crate) fn ensure_cached(&self, system_adts: &BTreeSet<Typ>, cache: &mut BTreeMap<RTyp, usize>) {
-        if cache.contains_key(self) {
-            return;
+    pub(crate) fn ensure_cached(&self, cache: &mut BTreeMap<RTyp, usize>, degree: usize,) -> Res<()> {
+        if !cache.contains_key(self) {
+            if self.is_recursive()? {
+                cache.insert(self.clone(), degree);
+            } else {
+                self.compute_approximation_degree(cache, degree)?;
+            }
         }
-        else if self.is_recursive(system_adts).is_ok_and(|v| v) {
-        cache.insert(self.clone(), 1);
-    } else {
-        self.compute_approximation_degree(system_adts, cache);
+        Ok(())
     }
-}
-
+    
     /// Checks a type is legal.
     pub fn check(&self) -> Res<()> {
         match self {

--- a/src/term/typ.rs
+++ b/src/term/typ.rs
@@ -2,7 +2,10 @@
 
 use hashconsing::{HConsed, HashConsign};
 
-use crate::{common::*, dtyp::TPrmMap};
+use crate::{
+    common::*,
+    dtyp::{PartialTyp, RDTyp, TPrmMap},
+};
 
 hashconsing::consign! {
   /// Type factory.
@@ -167,6 +170,135 @@ impl RTyp {
             None
         }
     }
+
+    pub fn dtyp_dependencies(
+        &self,
+        system_adts: &BTreeSet<Typ>,
+    ) -> Res<BTreeSet<Typ>> {
+        let mut dependencies = BTreeSet::new();
+        if let Some((dtyp, generic_rtyps)) = self.dtyp_inspect() {
+            for (_, args) in dtyp.news.iter() {
+                for (_, arg_ptyp) in args.iter() {
+                    match arg_ptyp {
+                        PartialTyp::Typ(rtyp) => match rtyp.get() {
+                            RTyp::DTyp { dtyp: _, prms: _ } => {
+                                dependencies.insert(rtyp.clone());
+                            }
+                            RTyp::Int => {}
+                            _ => {
+                                return Err(Error::from_kind(ErrorKind::Msg(format!(
+                                    "I was expecting an ADT or an Int, found {rtyp}"
+                                ))));
+                            }
+                        },
+                        PartialTyp::DTyp(_, _, _) => {
+                            if let Ok(arg_rtyp) = arg_ptyp.to_type(Some(generic_rtyps)) {
+                                if let Some(dep_typ) = system_adts.get(&arg_rtyp) {
+                                    dependencies.insert(dep_typ.clone());
+                                }
+                            }
+                        }
+                        PartialTyp::Param(_) => {}
+                        _ => {
+                            return Err(Error::from_kind(ErrorKind::Msg(format!(
+                                "I was expecting a concrete type or a generic, found {arg_ptyp} in {dtyp}"
+                            ))));
+                        }
+                    }
+                }
+            }
+            for generic_rtyp in generic_rtyps.iter() {
+                match generic_rtyp.get() {
+                    RTyp::DTyp { dtyp: _, prms: _ } => {
+                        dependencies.insert(generic_rtyp.clone());
+                    }
+                    RTyp::Int => {}
+                    _ => {
+                        return Err(Error::from_kind(ErrorKind::Msg(format!(
+                            "I was expecting either an ADT or an Int, found {generic_rtyp}"
+                        ))));
+                    }
+                }
+            }
+        }
+        Ok(dependencies)
+    }
+
+    pub fn is_recursive(&self, system_adts: &BTreeSet<Typ>,) -> Res<bool> {
+        let mut stack = vec![self.clone()];
+        let mut already_visted = BTreeSet::new();
+        while let Some(typ) = stack.pop() {
+            already_visted.insert(typ.clone());
+            for dep in typ.dtyp_dependencies(system_adts)?.iter() {
+                if dep.get() == self {
+                    return Ok(true);
+                }
+                if !already_visted.contains(dep.get()) {
+                    stack.push(dep.get().clone());
+                }
+            }
+        }
+        return Ok(false);
+    }
+
+    /// Returns the approximation degree of the current **simplifiable** [`RTyp`]
+    /// as a [`usize`].
+    ///
+    /// # Arguments
+    ///
+    /// * `system_adts` - The set of all the known ADT types in the system.
+    /// * `cache` - A map of the ADTs insepcted so far.
+    ///
+    /// # Returns
+    ///
+    /// A [`usize`] representing the initial approximation degree of [`RTyp`].
+    pub fn compute_approximation_degree(
+        &self,
+        system_adts: &BTreeSet<Typ>,
+        cache: &mut BTreeMap<Self, usize>,
+    ) {
+        if cache.contains_key(self) {
+            return;
+        }
+
+        if self.is_recursive(system_adts).is_ok_and(|v| v) {
+            cache.insert(self.clone(), 1);
+            return;
+        }
+
+        let Some((dtyp, generic_rtyps)) = self.dtyp_inspect() else {
+            cache.insert(self.clone(), 1);
+            return;
+        };
+
+        let constructor_degree = dtyp
+            .news
+            .iter()
+            .map(|(_, args)| {
+                args.iter()
+                    .map(|(_, arg_ptyp)| arg_ptyp.degree_of_arg(generic_rtyps, system_adts, cache))
+                    .sum::<usize>()
+            })
+            .max()
+            .unwrap_or(0);
+
+        // Need one extra digit to discriminate between multiple constructors.
+        let discriminant_bit = if dtyp.news.len() > 1 { 1 } else { 0 };
+
+        cache.insert(self.clone(), constructor_degree + discriminant_bit);
+    }
+
+    /// Ensures [`RTtyp`] has an entry in `cache`, recursing if necessary.
+    pub(crate) fn ensure_cached(&self, system_adts: &BTreeSet<Typ>, cache: &mut BTreeMap<RTyp, usize>) {
+        if cache.contains_key(self) {
+            return;
+        }
+        else if self.is_recursive(system_adts).is_ok_and(|v| v) {
+        cache.insert(self.clone(), 1);
+    } else {
+        self.compute_approximation_degree(system_adts, cache);
+    }
+}
 
     /// Checks a type is legal.
     pub fn check(&self) -> Res<()> {


### PR DESCRIPTION
Some catamorphism can be determined before running Catalia, I called these categories:

1. Statically simplifiable: if either it has no ADTs among its type dependencies or all of its dependencies are statically simplifiable. The catamoirphism is fixed before starting the CEGAR loop.
2. Dynamically simplifiable: if the type is not statically simplifiable and it is non-recursive. The catamorphism is the concatenation of the various arguments, its approximation degree varies accordingly.

Now Catalia is able to construct a graph for the dependency analysis and simplify these ADTs; and build linear templates using these simplifications. The extension to other templates types is pretty straightforward.

Once this PR meets the quality standard required I will proceed with a squash of all the commits